### PR TITLE
Racing Bands Visualizer

### DIFF
--- a/LEDs/LEDDomeOutput.cs
+++ b/LEDs/LEDDomeOutput.cs
@@ -444,21 +444,19 @@ namespace Spectrum.LEDs {
         return 0x000000;
       }
       var num_colors = maxIndex - minIndex;
-      int min_color_idx = (int)(pixelPos * num_colors);
-      int max_color_idx = (int)(pixelPos * num_colors + 1);
+      int minColorIdx = (int)(pixelPos * num_colors);
+      int maxColorIdx = (int)(pixelPos * num_colors + 1);
       // Rescale the position, so it's between the colors
       // (pixelPos - min_color_idx/num_colors)*num_colors
-      double scaledPixelPos = (pixelPos - 1.0 * min_color_idx / num_colors) * num_colors;
+      double scaledPixelPos = (pixelPos - 1.0 * minColorIdx / num_colors) * num_colors;
       if (scaledPixelPos < 0 || scaledPixelPos > 1) {
         throw new ArgumentException("Pixel Position out of range: " + pixelPos.ToString());
       }
       int absoluteIndexMin = LEDColor.GetAbsoluteColorIndex(
-        min_color_idx,
-        this.config.colorPaletteIndex
+        minColorIdx, this.config.colorPaletteIndex
       );
       int absoluteIndexMax = LEDColor.GetAbsoluteColorIndex(
-        max_color_idx,
-        this.config.colorPaletteIndex
+        maxColorIdx, this.config.colorPaletteIndex
       );
       if (
         this.config.colorPalette.colors == null ||
@@ -478,8 +476,8 @@ namespace Spectrum.LEDs {
         return this.GetSingleColor(absoluteIndexMin);
       }
       LEDColor color = new LEDColor(
-        this.GetSingleColor(min_color_idx),
-        this.GetSingleColor(max_color_idx));
+        this.GetSingleColor(minColorIdx),
+        this.GetSingleColor(maxColorIdx));
       return LEDColor.ScaleColor(
         color.GradientColor(scaledPixelPos, focusPos, wrap),
         this.config.domeMaxBrightness * this.config.domeBrightness

--- a/LEDs/LEDDomeOutput.cs
+++ b/LEDs/LEDDomeOutput.cs
@@ -381,7 +381,7 @@ namespace Spectrum.LEDs {
       return strutLengths[controlBoxStrutOrder[i][strutsLeft]];
     }
 
-    public int GetSingleColor(int index) {
+    public int GetSingleColor(int index, double intensity = 1.0) {
       if (this.config.beatBroadcaster.CurrentlyFlashedOff) {
         return 0x000000;
       }
@@ -391,7 +391,7 @@ namespace Spectrum.LEDs {
       );
       return LEDColor.ScaleColor(
         this.config.colorPalette.GetSingleColor(absoluteIndex),
-        this.config.domeMaxBrightness * this.config.domeBrightness
+        this.config.domeMaxBrightness * this.config.domeBrightness * intensity
       );
     }
 
@@ -425,6 +425,62 @@ namespace Spectrum.LEDs {
           focusPos,
           wrap
         ),
+        this.config.domeMaxBrightness * this.config.domeBrightness
+      );
+    }
+    public int GetGradientBetweenColors(
+      int min_index,
+      int max_index,
+      double pixelPos,
+      double focusPos,
+      bool wrap
+    ) {
+      // Return a color evenly scaled between min index and max index, based on the pixel position.
+      if(pixelPos < 0 || pixelPos > 1) {
+        throw new ArgumentException("Pixel Position out of range: " + pixelPos.ToString());
+      }
+      if (this.config.beatBroadcaster.CurrentlyFlashedOff) {
+        return 0x000000;
+      }
+      var num_colors = max_index - min_index;
+      int min_color_idx = (int)(pixelPos * num_colors);
+      int max_color_idx = (int)(pixelPos * num_colors + 1);
+      // Rescale the position, so it's between the colors
+      // (pixelPos - min_color_idx/num_colors)*num_colors
+      double scaledPixelPos = (pixelPos - 1.0*min_color_idx/num_colors)*num_colors;
+      if(scaledPixelPos < 0 || scaledPixelPos > 1) {
+        throw new ArgumentException("Pixel Position out of range: " + pixelPos.ToString());
+      }
+      int absoluteIndexMin = LEDColor.GetAbsoluteColorIndex(
+        min_color_idx,
+        this.config.colorPaletteIndex
+      );
+      int absoluteIndexMax = LEDColor.GetAbsoluteColorIndex(
+        max_color_idx,
+        this.config.colorPaletteIndex
+      );
+      if (
+        this.config.colorPalette.colors == null ||
+        this.config.colorPalette.colors.Length <= absoluteIndexMin ||
+        this.config.colorPalette.colors[absoluteIndexMin] == null
+      ) {
+        return 0x000000;
+      }
+      if (
+        this.config.colorPalette.colors == null ||
+        this.config.colorPalette.colors.Length <= absoluteIndexMax ||
+        this.config.colorPalette.colors[absoluteIndexMax] == null
+      ) {
+        return 0x000000;
+      }
+      if (!this.config.colorPalette.colors[absoluteIndexMin].IsGradient) {
+        return this.GetSingleColor(absoluteIndexMin);
+      }
+      LEDColor color = new LEDColor(
+        this.GetSingleColor(min_color_idx), 
+        this.GetSingleColor(max_color_idx));
+      return LEDColor.ScaleColor(
+        color.GradientColor(scaledPixelPos, focusPos, wrap),
         this.config.domeMaxBrightness * this.config.domeBrightness
       );
     }

--- a/LEDs/LEDDomeOutput.cs
+++ b/LEDs/LEDDomeOutput.cs
@@ -381,7 +381,7 @@ namespace Spectrum.LEDs {
       return strutLengths[controlBoxStrutOrder[i][strutsLeft]];
     }
 
-    public int GetSingleColor(int index, double intensity = 1.0) {
+    public int GetSingleColor(int index) {
       if (this.config.beatBroadcaster.CurrentlyFlashedOff) {
         return 0x000000;
       }
@@ -391,7 +391,7 @@ namespace Spectrum.LEDs {
       );
       return LEDColor.ScaleColor(
         this.config.colorPalette.GetSingleColor(absoluteIndex),
-        this.config.domeMaxBrightness * this.config.domeBrightness * intensity
+        this.config.domeMaxBrightness * this.config.domeBrightness
       );
     }
 
@@ -428,27 +428,28 @@ namespace Spectrum.LEDs {
         this.config.domeMaxBrightness * this.config.domeBrightness
       );
     }
+
     public int GetGradientBetweenColors(
-      int min_index,
-      int max_index,
+      int minIndex,
+      int maxIndex,
       double pixelPos,
       double focusPos,
       bool wrap
     ) {
       // Return a color evenly scaled between min index and max index, based on the pixel position.
-      if(pixelPos < 0 || pixelPos > 1) {
+      if (pixelPos < 0 || pixelPos > 1) {
         throw new ArgumentException("Pixel Position out of range: " + pixelPos.ToString());
       }
       if (this.config.beatBroadcaster.CurrentlyFlashedOff) {
         return 0x000000;
       }
-      var num_colors = max_index - min_index;
+      var num_colors = maxIndex - minIndex;
       int min_color_idx = (int)(pixelPos * num_colors);
       int max_color_idx = (int)(pixelPos * num_colors + 1);
       // Rescale the position, so it's between the colors
       // (pixelPos - min_color_idx/num_colors)*num_colors
-      double scaledPixelPos = (pixelPos - 1.0*min_color_idx/num_colors)*num_colors;
-      if(scaledPixelPos < 0 || scaledPixelPos > 1) {
+      double scaledPixelPos = (pixelPos - 1.0 * min_color_idx / num_colors) * num_colors;
+      if (scaledPixelPos < 0 || scaledPixelPos > 1) {
         throw new ArgumentException("Pixel Position out of range: " + pixelPos.ToString());
       }
       int absoluteIndexMin = LEDColor.GetAbsoluteColorIndex(
@@ -477,14 +478,13 @@ namespace Spectrum.LEDs {
         return this.GetSingleColor(absoluteIndexMin);
       }
       LEDColor color = new LEDColor(
-        this.GetSingleColor(min_color_idx), 
+        this.GetSingleColor(min_color_idx),
         this.GetSingleColor(max_color_idx));
       return LEDColor.ScaleColor(
         color.GradientColor(scaledPixelPos, focusPos, wrap),
         this.config.domeMaxBrightness * this.config.domeBrightness
       );
     }
-
   }
 
 }

--- a/README.md
+++ b/README.md
@@ -20,16 +20,3 @@ Note that it is currently only possible to build and run Spectrum on a 64-bit Wi
 5. Recursively clone this repo: `git clone --recursive https://github.com/campmindshark/spectrum`
 6. Open the Spectrum solution in Visual Studio and run it!
     - You will need Internet access for the first build, so if you're heading to TTITD, please compile beforehand, once for Release and once for Debug.
-
-## Dome Simulator
-To test out the dome, enable the simulator under the LED Dome tab:
-![Simulator Settings ](https://user-images.githubusercontent.com/671052/63136544-847d7d80-bfa0-11e9-81e9-bba208a135fc.png)
-
-When it's working, you should see something like the following:
-![Dome Simulator](https://user-images.githubusercontent.com/671052/63136574-9c550180-bfa0-11e9-9d50-6d1cf4cc347c.png)
-
-## Troubleshooting
-- **Unsupported Wave Format**: This message may mean that the hardcoded 
-  `audioFormatSampleFrequency` in `AudioInput.cs` is not set to the sample frequency of 
-  your audio card. Lookup the frequency of your audio card with "Windows Search -> 
-  Sound -> Properties -> Advanced" and set `audioFormatSampleFrequency` to it.

--- a/README.md
+++ b/README.md
@@ -20,3 +20,16 @@ Note that it is currently only possible to build and run Spectrum on a 64-bit Wi
 5. Recursively clone this repo: `git clone --recursive https://github.com/campmindshark/spectrum`
 6. Open the Spectrum solution in Visual Studio and run it!
     - You will need Internet access for the first build, so if you're heading to TTITD, please compile beforehand, once for Release and once for Debug.
+
+## Dome Simulator
+To test out the dome, enable the simulator under the LED Dome tab:
+![Simulator Settings ](https://user-images.githubusercontent.com/671052/63136544-847d7d80-bfa0-11e9-81e9-bba208a135fc.png)
+
+When it's working, you should see something like the following:
+![Dome Simulator](https://user-images.githubusercontent.com/671052/63136574-9c550180-bfa0-11e9-9d50-6d1cf4cc347c.png)
+
+## Troubleshooting
+- **Unsupported Wave Format**: This message may mean that the hardcoded 
+  `audioFormatSampleFrequency` in `AudioInput.cs` is not set to the sample frequency of 
+  your audio card. Lookup the frequency of your audio card with "Windows Search -> 
+  Sound -> Properties -> Advanced" and set `audioFormatSampleFrequency` to it.

--- a/Spectrum/Operator.cs
+++ b/Spectrum/Operator.cs
@@ -102,6 +102,12 @@ namespace Spectrum {
         audio,
         dome
       ));
+      this.visualizers.Add(new LEDDomeRaceVisualizer(
+        this.config,
+        audio,
+        midi,
+        dome
+      ));
       this.visualizers.Add(new LEDDomeJkmdTestVisualizer(
         this.config,
         audio,

--- a/Spectrum/Spectrum.csproj
+++ b/Spectrum/Spectrum.csproj
@@ -91,6 +91,7 @@
     <Compile Include="Converter\SpecificValuesConverter.cs" />
     <Compile Include="Converter\FPSToBrushConverter.cs" />
     <Compile Include="Converter\StringJoinConverter.cs" />
+    <Compile Include="Visualizers\LEDDomeRaceVisualizer.cs" />
     <Compile Include="Visualizers\LEDDomeRadialVisualizer.cs" />
     <Compile Include="Visualizers\LEDDomeTVStaticVisualizer.cs" />
     <Compile Include="Visualizers\LEDDomeJkmdTestVisualizer.cs" />

--- a/Spectrum/Visualizers/LEDDomeRaceVisualizer.cs
+++ b/Spectrum/Visualizers/LEDDomeRaceVisualizer.cs
@@ -253,44 +253,7 @@ namespace Spectrum {
       return new Input[] { this.audio };
     }
 
-    // This is where the magic happens. As long as this Visualizer has the
-    // highest priority for LEDDomeOutput, the Operator thread will call
-    // Visualize once per tick
     public void Visualize() {
-
-      //-----------------------------------------------------------------------
-      // TRACKING THE LEVEL (VOLUME)
-      //-----------------------------------------------------------------------
-
-      // volume is a float from 0.0 to 1.0 that represents the current total
-      // output "level", aka volume
-      float volume = this.audio.Volume;
-
-      //-----------------------------------------------------------------------
-      // COLORS
-      //-----------------------------------------------------------------------
-
-      // Notes on colors:
-      // (1) We represent colors using RGB values stored as ints. Each int
-      //   consists of three concatenated bytes (red, green, and blue).
-      // (2) These RGB values should not be thought of in the same way as RGB
-      //   values in CSS or HTML. The important distinction is that point LEDs
-      //   cannot display composite colors such as brown and pink. Each LED
-      //   can only display a single wavelength of light at a given moment.
-      // (3) An easy way to imagine how a given RGB value will look: scale each
-      //   component (red, green, and blue) up equally until at least one of
-      //   the components is maxed out at 255. The scale factor represents the
-      //   brightness, and the scaled-up color is what you will see on the
-      //   LED. SimulatorUtils.GetComputerColor can take an RGB int and return
-      //   the scaled-up color.
-      // (4) The VJ is able to configure 8 distinct color palettes, each
-      //   consisting of 8 pairs of colors. Each pair represents a gradient,
-      //   meaning that for each color palette, the VJ has 16 color inputs.
-      // (5) By calling the methods below on this.dome instead of on
-      //   this.config.colorPalette, we make sure that the brightness is
-      //   scaled according to Spectrum's config. We never run the dome at
-      //   100% brightness, and our power supplies are not provisioned for it.
-
       //-----------------------------------------------------------------------
       // SETTING THE RACERS
       //-----------------------------------------------------------------------

--- a/Spectrum/Visualizers/LEDDomeRaceVisualizer.cs
+++ b/Spectrum/Visualizers/LEDDomeRaceVisualizer.cs
@@ -24,6 +24,7 @@ namespace Spectrum {
       public Rotation rotation;
       public Size size;
       public Coloring coloring;
+
       public RacerConfig(Rotation r, Size s, Coloring c) {
         rotation = r;
         size = s;
@@ -57,6 +58,7 @@ namespace Spectrum {
       private int idx; // Length of the Racer in Radians, 0 to 2*pi
       private double AccumulatedSeconds;
       private RacerConfig conf;
+
       public Racer(int idx, int num_racers, RacerConfig racer_config) {
         conf = racer_config;
         double width = conf.size == Size.Small ? 1.0 / 8 :
@@ -68,6 +70,7 @@ namespace Spectrum {
         this.Radians = 2 * Math.PI * width;
         AccumulatedSeconds = 0;
       }
+
       public void Move(double numSeconds, AudioInput audio, Configuration config) {
         // Could use classes for this, but eh.
         double revsPerSec =
@@ -79,6 +82,7 @@ namespace Spectrum {
         double radsPerSecond = Math.PI * 2 * revsPerSec;
         MoveRads(numSeconds, radsPerSecond);
       }
+
       public int Color(LEDDomeOutput dome, Configuration config, double loc_y, double loc_ang) {
         if (conf.coloring == Coloring.Fade) {
           return LEDColor.ScaleColor(dome.GetSingleColor(this.idx), loc_ang);
@@ -109,14 +113,17 @@ namespace Spectrum {
         }
         AccumulatedSeconds = 0;
       }
+
       public double RevsPerSecondVolume(AudioInput audio, Configuration config) {
         // Square the volume to give a bigger umph.
         return audio.Volume + config.domeVolumeRotationSpeed / 12;
       }
+
       public double RevsPerSecondVolumeSquared(AudioInput audio, Configuration config) {
         // Square the volume to give a bigger umph.
         return audio.Volume * audio.Volume + config.domeVolumeRotationSpeed / 12;
       }
+
       public double RevsPerSecondBeats(AudioInput audio, Configuration config) {
         double BPS =
           // If we don't have a beet counter, fake it as 60 BPM.

--- a/Spectrum/Visualizers/LEDDomeRaceVisualizer.cs
+++ b/Spectrum/Visualizers/LEDDomeRaceVisualizer.cs
@@ -2,349 +2,442 @@
 using Spectrum.Audio;
 using Spectrum.MIDI;
 using Spectrum.LEDs;
+using System;
 using System.Collections.Generic;
 
 namespace Spectrum
 {
 
-    class LEDDomeRaceVisualizer : Visualizer
+  class LEDDomeRaceVisualizer : Visualizer
+  {
+
+    private readonly Configuration config;
+    private readonly AudioInput audio;
+    private readonly MidiInput midi;
+    private readonly LEDDomeOutput dome;
+    
+    // How much spacing should be in between each racer. 
+    // Determines racer size. 
+    // 0 means right next to eachother. 1 means they have a size of 0.
+    private double racer_spacing = .3;
+
+    private class Racer
+    {
+      public double Y { get; set; }  // Location in height 1 is top, 0 is bottom.
+      public double Angle { get; protected set; } // Location of the Racer in Radians, -pi to pi
+      public double Radians { get; protected set; } // Length of the Racer in Radians, 0 to 2*pi
+      private double AccumulatedSeconds;
+      public Racer(int idx, int num_racers)
+      {
+        this.Y = 1.0 * idx / num_racers + .5;
+        this.Angle = 0;
+        this.Radians = 2*Math.PI * 1/4;
+        AccumulatedSeconds = 0;
+      }
+
+      private void MoveRads(double numSeconds, double radsPerSecond) {
+        double rads = (numSeconds + AccumulatedSeconds) * radsPerSecond;
+        if(rads < .001) {
+          AccumulatedSeconds += numSeconds;
+          return;
+        }
+        Angle += rads;
+        if(Angle > Math.PI) {
+          Angle -= Math.PI*2;
+        }
+        AccumulatedSeconds = 0;
+      }
+      public void Move(double numSeconds, AudioInput audio, Configuration config) {
+        double radsPerSecond = RadsPerSecondVolume(audio, config);
+        MoveRads(numSeconds, radsPerSecond);
+      }
+      public double RadsPerSecondVolume(AudioInput audio, Configuration config) {
+        return 2*Math.PI * audio.Volume * audio.Volume + 2*Math.PI * config.domeVolumeRotationSpeed / 12;
+      }
+      public double RadsPerSecondBeats(Configuration config) {
+        return Math.PI/4 * config.beatBroadcaster.MeasureLength / 500;
+      }
+    }
+
+    private Racer[] Racers { get; set; }
+    private long lastTicks { get; set; }
+    private int numRacers { get; set; }
+
+    private Tuple<Racer, double, int> GetRacer(double Y, double ang) {
+      // e.g., say 2 racers, racer0 centered on .25; racer1 centered on .75.
+      // Y = .4. We should return the first racer if in spacing.
+      if(Y > .9999) {
+         Y = .9999;
+      }
+      double racer_loc = Y * numRacers; // Scale from 0 to num_racers
+      int racer_idx = (int)(racer_loc);
+      racer_loc -= racer_idx; // Scale from 0 to 1, same as  
+      racer_loc -= .5; // Scale from -.5 to .5
+      racer_loc = Math.Abs(racer_loc);
+      if(racer_loc > racer_spacing) {
+        return null;
+      }
+      Racer r = this.Racers[racer_idx];
+      if(racer_idx == 0){
+        if(r.Angle > .1) {
+          var q = 2;
+        }
+      }
+      // Offset is how many radians ahead of the start angle.
+      double start_angle = r.Angle;
+      if(start_angle < 0) {
+        start_angle += 2*Math.PI;
+      }
+      if(ang < 0) {
+        ang += 2*Math.PI;
+      }
+      double offset = ang - start_angle;
+      if(offset < 0) {
+        offset += Math.PI*2;
+      }
+      var doShow = offset > 2*Math.PI - r.Radians;
+      if(!doShow) {
+        return null;
+      }
+      return new Tuple<Racer, double, int>(r, racer_loc, racer_idx);
+    }
+
+    public LEDDomeRaceVisualizer(
+     Configuration config,
+     AudioInput audio,
+     MidiInput midi,
+     LEDDomeOutput dome
+     )
+    {
+      this.config = config;
+      this.audio = audio;
+      this.midi = midi;
+      this.dome = dome;
+      // Create new racers.
+      this.numRacers = this.config.domeVolumeAnimationSize;
+      this.Racers = new Racer[this.numRacers];
+      for (int i = 0; i < this.numRacers; i++) {
+        this.Racers[i] = new Racer(i, this.numRacers);
+      }
+      this.lastTicks = -1;
+      // This call is necessary to make sure the Operator considers this
+      // Visualizer when comparing priorities for LEDDomeOutput. If you skip it
+      // your Visualizer will never run
+      this.dome.RegisterVisualizer(this);
+    }
+
+    public int Priority
+    {
+      get
+      {
+        // The mapping between Visualizers and their corresponding domeActiveVis
+        // integer value is determined in the condition below, as well as in the
+        // Bind call for domeActiveVis in MainWindow.xaml.cs
+        if (this.config.domeActiveVis != 2)
+        {
+          // By setting the priority to 0, we guarantee that this Visualizer
+          // will not run
+          return 0;
+        }
+        // There is a "screensaver" Visualizer with priority 1 associated with
+        // LEDDomeOutput (LEDDomeTVStaticVisualizer). The intention is to run
+        // that Visualizer when there is no audio input. If you are writing a
+        // Visualizer that depends on audio input, consider disabling it when
+        // the audio is off using the following condition:
+        if (this.audio.isQuiet)
+        {
+          return 0;
+        }
+        // You can return any number higher than 1 here to make sure this
+        // Visualizer runs and the screensaver Visualizer doesn't
+        return 2;
+      }
+    }
+
+    // When the Operator determines that this Visualizer has the highest
+    // priority for LEDDomeOutput, it will set the Enabled property below to
+    // true. Conversely, when it determines that this Visualizer no longer has
+    // the highest priority, it will set it to false. Note that the Visualize
+    // method below will be called if and only if Enabled is set to true.
+
+    // If you don't need to do any sort of preparation when your Visualizer is
+    // enabled, you can just use the following line to define the property:
+    // public bool Enabled { get; set; }
+    // Otherwise, if you want to do something special either when being enabled
+    // or disabled, use the following code:
+    private bool enabled = false;
+    public bool Enabled
+    {
+      get
+      {
+        return this.enabled;
+      }
+      set
+      {
+        if (value == this.enabled)
+        {
+          return;
+        }
+        // Any code that you want to run when the Visualizer is enabled or when
+        // it's disabled should go here
+        this.enabled = value;
+      }
+    }
+
+    public Input[] GetInputs()
+    {
+      // In order for the Operator to know which Inputs need to be enabled, you
+      // should return the ones you are currently using here. If your Visualizer
+      // only needs certain Inputs under certain conditions, you can put
+      // conditional logic here
+      return new Input[] { this.audio };
+    }
+
+    // This is where the magic happens. As long as this Visualizer has the
+    // highest priority for LEDDomeOutput, the Operator thread will call
+    // Visualize once per tick
+    public void Visualize()
     {
 
-        private readonly Configuration config;
-        private readonly AudioInput audio;
-        private readonly MidiInput midi;
-        private readonly LEDDomeOutput dome;
+      //-----------------------------------------------------------------------
+      // TRACKING THE BEAT
+      //-----------------------------------------------------------------------
+
+      // progressThroughMeasure is a double from 0.0 to 1.0 that represents the
+      // progress through the current musical measure at this instant in time
+      double progressThroughMeasure =
+        this.config.beatBroadcaster.ProgressThroughMeasure;
+
+      // ProgressThroughBeat can be used to get the progress through any
+      // multiple of a musical measure. Note that the measure is DIVIDED by the
+      // parameter you pass to ProgressThroughBeat, so eg. if you want the
+      // return value to hit 1.0 on every quarter note, you should pass in 4.0
+      double progressThroughHalfMeasure =
+        this.config.beatBroadcaster.ProgressThroughBeat(2.0);
+
+      //-----------------------------------------------------------------------
+      // TRACKING THE LEVEL (VOLUME)
+      //-----------------------------------------------------------------------
+
+      // volume is a float from 0.0 to 1.0 that represents the current total
+      // output "level", aka volume
+      float volume = this.audio.Volume;
+
+      // The VJ has the ability to configure a "channel" that represents the
+      // level within a specific frequency range. They can configure up to 8
+      // distinct channels. Besides configuring a frequency range applied to the
+      // audio input, it is also possible for the VJ to associate a channel with
+      // a MIDI note coming from a MIDI input. In general, it's probably better
+      // to use channel0Level instead of Volume, since it gives the VJ more
+      // flexibility to configure the Visualizer. Channel 0 is usually
+      // configured to be the same as Volume
+      double channel0Level = this.audio.LevelForChannel(0);
+
+      //-----------------------------------------------------------------------
+      // RESPONDING TO A KICK OR SNARE
+      //-----------------------------------------------------------------------
+
+      // An AudioEvent is queued up when Spectrum detects either a Kick or a
+      // Snare. On every call to Visualize, audioEventsSinceLastTick will
+      // contain a list of detected Kick or Snare events that have occured since
+      // the last call to Visualize.
+      // public enum AudioDetectorType : byte { Kick, Snare }
+      // public class AudioEvent {
+      //   public AudioDetectorType type;
+      //   public double significance;
+      // }
+      List<AudioEvent> audioEventsSinceLastTick =
+        this.audio.GetEventsSinceLastTick();
+
+      //-----------------------------------------------------------------------
+      // MIDI DEVICES
+      //-----------------------------------------------------------------------
+
+      // knobValue is a double from 0.0 to 1.0 that represents the current
+      // state of knob #15 on MIDI device #0. You can assume that the active
+      // MIDI deviceIndex is always 0. Which knob corresponds to #15 will depend
+      // on the MIDI board in question.
+      double knobValue = this.midi.GetKnobValue(0, 15);
+
+      // noteVelocity is a double from 0.0 to 1.0 that represents the velocity
+      // with which note #15 on MIDI device #0 was hit. The velocity is set to a
+      // non-zero value when the note is pressed, and is reset to zero when the
+      // note is released. If noteVelocity is non-zero, that means the note in
+      // question is currently depressed. You can assume that the active MIDI
+      // deviceIndex is always 0. Which note corresponds to #15 will depend on
+      // the MIDI board in question.
+      double noteVelocity = this.midi.GetNoteVelocity(0, 15);
+
+      // An MidiCommand is queued up whenever input is detected from a MIDI
+      // device. On every call to Visualize, midiCommandsSinceLastTick will
+      // contain an array of MIDI events that have occured since the last call
+      // to Visualize. The index distinguishes which Knob, Note, or Program
+      // button was involved. Note that when pressing and releasing a Note, two
+      // events will be created. The first will be issued when the note is
+      // pressed, and its value will be the non-zero velocity with which the
+      // press occurred. The second will be issued when the note is released,
+      // and its value will be zero.
+      // public enum MidiCommandType : byte { Knob, Note, Program }
+      // public struct MidiCommand {
+      //   public int deviceIndex;
+      //   public MidiCommandType type;
+      //   public int index;
+      //   public double value;
+      // }
+      MidiCommand[] midiCommandsSinceLastTick =
+        this.midi.GetCommandsSinceLastTick();
+
+      //-----------------------------------------------------------------------
+      // COLORS
+      //-----------------------------------------------------------------------
+
+      // Notes on colors:
+      // (1) We represent colors using RGB values stored as ints. Each int
+      //   consists of three concatenated bytes (red, green, and blue).
+      // (2) These RGB values should not be thought of in the same way as RGB
+      //   values in CSS or HTML. The important distinction is that point LEDs
+      //   cannot display composite colors such as brown and pink. Each LED
+      //   can only display a single wavelength of light at a given moment.
+      // (3) An easy way to imagine how a given RGB value will look: scale each
+      //   component (red, green, and blue) up equally until at least one of
+      //   the components is maxed out at 255. The scale factor represents the
+      //   brightness, and the scaled-up color is what you will see on the
+      //   LED. SimulatorUtils.GetComputerColor can take an RGB int and return
+      //   the scaled-up color.
+      // (4) The VJ is able to configure 8 distinct color palettes, each
+      //   consisting of 8 pairs of colors. Each pair represents a gradient,
+      //   meaning that for each color palette, the VJ has 16 color inputs.
+      // (5) By calling the methods below on this.dome instead of on
+      //   this.config.colorPalette, we make sure that the brightness is
+      //   scaled according to Spectrum's config. We never run the dome at
+      //   100% brightness, and our power supplies are not provisioned for it.
+
+      // GetSingleColor retrieves the color pair at the given index for the
+      // current color palette. It then discards the second color in the pair,
+      // returning only the first color in the pair.
+      int firstSingleColor = this.dome.GetSingleColor(0);
+
+      // GetGradientColor is a bit more complicated. It retrieves the color pair
+      // at the given index for the current color palette, and then blends that
+      // pair according to the rest of the parameters.
+      // Imagine a strut that is being colored according to a gradient.
+      // (*) The second parameter (0.5 below) is a double from 0.0 to 1.0 that
+      //   represents the position along that strut. So ignoring the last two
+      //   parameters, the second parameter will determine how much of each
+      //   color to mix. 0.5 means half of each, whereas 0.0 means just the
+      //   first color, and 1.0 means just the second color.
+      // (*) The third parameter (0.0 below) is a double from 0.0 to 1.0 that
+      //   represents an offset we add to the second parameter. Its purpose is
+      //   to allow the Visualizer author to animate the gradient along a
+      //   strut. If you set it to 0.25, then the LED one quarter of the way
+      //   through the strut will be the first color, and the one right before
+      //   it will be the second color. Correspondingly, the first LED on the
+      //   strut would be 75% second color, 25% first color.
+      // (*) The final parameter (false below) is a boolean that represents
+      //   whether we want the gradient to "wrap" or not. If you set this to
+      //   true, in the above case where the third parameter is 0.25, instead
+      //   of seeing a sharp transition a quarter of the way in, the gradient
+      //   will be represented all the way through. In the 0.25 case, the LED
+      //   one quarter of the way in would be the first color, and the LED
+      //   three quarters of the way in would be the second color. The first
+      //   LED as well as the last LED on the strut would both be a 50/50
+      //   blend.
+      int middleOfStrutColor = this.dome.GetGradientColor(0, 0.5, 0.0, false);
+
+      //-----------------------------------------------------------------------
+      // STRUT LAYOUTS
+      //-----------------------------------------------------------------------
+
+      // Notes on strut layout:
+      // (1) Each LED on the dome is uniquely identified by a pair of a strut
+      //   index and an LED index.
+      // (2) The "key" that shows how strut indices are assigned can be viewed
+      //   in the dome simulator window. To open the dome simulator window,
+      //   first run Spectrum, then go to the "LED Dome" tab and check the box
+      //   labelled "Simulate". The simulator window should pop up. Click
+      //   "Show Key" to see the key.
+      // (3) Each strut has a number of LEDs, as well as a direction that
+      //   determines how its LED indices are assigned. The key provides this
+      //   information.
+      // (4) If you want to create a list of struts that you want to animate
+      //   together, you can press a series of struts in the key view. The
+      //   text box on the upper right will populate with a comma-separated
+      //   list of strut indices.
+
+      // StrutLayoutFactory contains utilities for generating collections of
+      // Struts, known as StrutLayouts.
+      // (*) The Strut class simply represents a strut by a given strut index,
+      //   as well as including a boolean for whether or not to reverse the
+      //   direction.
+      // (*) The StrutLayoutSegment class represents an unordered set of Struts.
+      //   There is no order within a StrutLayoutSegment, as all the Struts
+      //   within are expected to be animated together, at the same time.
+      // (*) A StrutLayout is simply an array of StrutLayoutSegments.
+      // (*) StrutLayoutFactory also assigns each vertex an index (calling them
+      //   "points"), which it uses in certain cases as user inputs.
+
+      // If you've ever seen the default dome animation in past years, it's
+      // basically using this layout. It's pretty domain-specific, and probably
+      // not worth getting into too much. You won't be calling this method, but
+      // if you're finding yourself making a complex strut layout, you might end
+      // up writing someting similar.
+      StrutLayout[] layouts = StrutLayoutFactory.ConcentricFromStartingPoints(
+        this.config,
+        // This list of points was determined manually
+        new HashSet<int>(new int[] { 22, 26, 30, 34, 38, 70 }),
+        4
+      );
+      
+      //-----------------------------------------------------------------------
+      // SETTING THE RACERS
+      //-----------------------------------------------------------------------
+      
+      this.racer_spacing = this.config.domeRadialSize / 4.0;
+      var curTicks = DateTime.Now.Ticks;
+      if(this.lastTicks == -1) { 
+        this.lastTicks = curTicks;
+      } else { 
+        double numSeconds = ((double)(curTicks - this.lastTicks)) / (1000 * 1000 * 10);
         
-        // How much spacing should be in between each racer. 
-        // Determines racer size. 
-        // 0 means right next to eachother. 1 means they have a size of 0.
-        private static readonly double racer_spacing = .3;
+        Racers[0].Move(numSeconds, audio, config);
+        Racers[2].Move(numSeconds, audio, config);
+        this.lastTicks = curTicks;
+      }
 
-        private class Racer
-        {
-            public double Y { get; set; }
-            public double Radians { get; set; }
-            public double Height { get; set; }
-            public Racer(int idx, int num_racers)
-            {
-                this.Y = 1.0 * idx / num_racers;
-                this.Radians = 0;
-                this.Height = 1.0 * racer_spacing / num_racers;
-            }
+      //-----------------------------------------------------------------------
+      // SETTING LEDS
+      //-----------------------------------------------------------------------
+
+      // This method is used to set an LED to a color. You identify the LED
+      // using a pair of a strut index and an LED index (see STRUT LAYOUTS
+      // above), and then provide a color to set that LED to.
+      this.dome.SetPixel(15, 20, firstSingleColor);
+      for (int i = 0; i < LEDDomeOutput.GetNumStruts(); i++) {
+        Strut strut = Strut.FromIndex(this.config, i);
+        var leds = LEDDomeOutput.GetNumLEDs(i);
+        for (int j = 0; j < leds; j++) {
+          var pixel_p = StrutLayoutFactory.GetProjectedLEDPointParametric(i, j);
+          // Vertical height
+          var y = 1.0 - pixel_p.Item4;
+          var rad = pixel_p.Item3;
+          Tuple<Racer, double, int> loc = this.GetRacer(y, rad);
+          if(loc != null) {
+            var color = this.dome.GetSingleColor(loc.Item3);
+            this.dome.SetPixel(i, j, color);
+          } else {
+            // color = 0 is off.
+            this.dome.SetPixel(i, j, 0);
+          }
         }
+      }
 
-        private Racer[] Racers { get; set; }
-        private long lastTicks { get; set; }
-
-        public LEDDomeRaceVisualizer(
-         Configuration config,
-         AudioInput audio,
-         MidiInput midi,
-         LEDDomeOutput dome
-       )
-        {
-            this.config = config;
-            this.audio = audio;
-            this.midi = midi;
-            this.dome = dome;
-            // Create new racers.
-            int num_racers = this.config.domeVolumeAnimationSize;
-            this.Racers = new Racer[num_racers];
-            for (int i = 0; i < this.config.domeVolumeAnimationSize; i++) {
-              this.Racers[i] = new Racer(i, num_racers);
-            }
-            this.lastTicks = -1;
-            // This call is necessary to make sure the Operator considers this
-            // Visualizer when comparing priorities for LEDDomeOutput. If you skip it
-            // your Visualizer will never run
-            this.dome.RegisterVisualizer(this);
-        }
-
-        public int Priority
-        {
-            get
-            {
-                // The mapping between Visualizers and their corresponding domeActiveVis
-                // integer value is determined in the condition below, as well as in the
-                // Bind call for domeActiveVis in MainWindow.xaml.cs
-                if (this.config.domeActiveVis != 3)
-                {
-                    // By setting the priority to 0, we guarantee that this Visualizer
-                    // will not run
-                    return 0;
-                }
-                // There is a "screensaver" Visualizer with priority 1 associated with
-                // LEDDomeOutput (LEDDomeTVStaticVisualizer). The intention is to run
-                // that Visualizer when there is no audio input. If you are writing a
-                // Visualizer that depends on audio input, consider disabling it when
-                // the audio is off using the following condition:
-                if (this.audio.isQuiet)
-                {
-                    return 0;
-                }
-                // You can return any number higher than 1 here to make sure this
-                // Visualizer runs and the screensaver Visualizer doesn't
-                return 2;
-            }
-        }
-
-        // When the Operator determines that this Visualizer has the highest
-        // priority for LEDDomeOutput, it will set the Enabled property below to
-        // true. Conversely, when it determines that this Visualizer no longer has
-        // the highest priority, it will set it to false. Note that the Visualize
-        // method below will be called if and only if Enabled is set to true.
-
-        // If you don't need to do any sort of preparation when your Visualizer is
-        // enabled, you can just use the following line to define the property:
-        // public bool Enabled { get; set; }
-        // Otherwise, if you want to do something special either when being enabled
-        // or disabled, use the following code:
-        private bool enabled = false;
-        public bool Enabled
-        {
-            get
-            {
-                return this.enabled;
-            }
-            set
-            {
-                if (value == this.enabled)
-                {
-                    return;
-                }
-                // Any code that you want to run when the Visualizer is enabled or when
-                // it's disabled should go here
-                this.enabled = value;
-            }
-        }
-
-        public Input[] GetInputs()
-        {
-            // In order for the Operator to know which Inputs need to be enabled, you
-            // should return the ones you are currently using here. If your Visualizer
-            // only needs certain Inputs under certain conditions, you can put
-            // conditional logic here
-            return new Input[] { this.audio, this.midi };
-        }
-
-        // This is where the magic happens. As long as this Visualizer has the
-        // highest priority for LEDDomeOutput, the Operator thread will call
-        // Visualize once per tick
-        public void Visualize()
-        {
-
-            //-----------------------------------------------------------------------
-            // TRACKING THE BEAT
-            //-----------------------------------------------------------------------
-
-            // progressThroughMeasure is a double from 0.0 to 1.0 that represents the
-            // progress through the current musical measure at this instant in time
-            double progressThroughMeasure =
-              this.config.beatBroadcaster.ProgressThroughMeasure;
-
-            // ProgressThroughBeat can be used to get the progress through any
-            // multiple of a musical measure. Note that the measure is DIVIDED by the
-            // parameter you pass to ProgressThroughBeat, so eg. if you want the
-            // return value to hit 1.0 on every quarter note, you should pass in 4.0
-            double progressThroughHalfMeasure =
-              this.config.beatBroadcaster.ProgressThroughBeat(2.0);
-
-            //-----------------------------------------------------------------------
-            // TRACKING THE LEVEL (VOLUME)
-            //-----------------------------------------------------------------------
-
-            // volume is a float from 0.0 to 1.0 that represents the current total
-            // output "level", aka volume
-            float volume = this.audio.Volume;
-
-            // The VJ has the ability to configure a "channel" that represents the
-            // level within a specific frequency range. They can configure up to 8
-            // distinct channels. Besides configuring a frequency range applied to the
-            // audio input, it is also possible for the VJ to associate a channel with
-            // a MIDI note coming from a MIDI input. In general, it's probably better
-            // to use channel0Level instead of Volume, since it gives the VJ more
-            // flexibility to configure the Visualizer. Channel 0 is usually
-            // configured to be the same as Volume
-            double channel0Level = this.audio.LevelForChannel(0);
-
-            //-----------------------------------------------------------------------
-            // RESPONDING TO A KICK OR SNARE
-            //-----------------------------------------------------------------------
-
-            // An AudioEvent is queued up when Spectrum detects either a Kick or a
-            // Snare. On every call to Visualize, audioEventsSinceLastTick will
-            // contain a list of detected Kick or Snare events that have occured since
-            // the last call to Visualize.
-            // public enum AudioDetectorType : byte { Kick, Snare }
-            // public class AudioEvent {
-            //   public AudioDetectorType type;
-            //   public double significance;
-            // }
-            List<AudioEvent> audioEventsSinceLastTick =
-              this.audio.GetEventsSinceLastTick();
-
-            //-----------------------------------------------------------------------
-            // MIDI DEVICES
-            //-----------------------------------------------------------------------
-
-            // knobValue is a double from 0.0 to 1.0 that represents the current
-            // state of knob #15 on MIDI device #0. You can assume that the active
-            // MIDI deviceIndex is always 0. Which knob corresponds to #15 will depend
-            // on the MIDI board in question.
-            double knobValue = this.midi.GetKnobValue(0, 15);
-
-            // noteVelocity is a double from 0.0 to 1.0 that represents the velocity
-            // with which note #15 on MIDI device #0 was hit. The velocity is set to a
-            // non-zero value when the note is pressed, and is reset to zero when the
-            // note is released. If noteVelocity is non-zero, that means the note in
-            // question is currently depressed. You can assume that the active MIDI
-            // deviceIndex is always 0. Which note corresponds to #15 will depend on
-            // the MIDI board in question.
-            double noteVelocity = this.midi.GetNoteVelocity(0, 15);
-
-            // An MidiCommand is queued up whenever input is detected from a MIDI
-            // device. On every call to Visualize, midiCommandsSinceLastTick will
-            // contain an array of MIDI events that have occured since the last call
-            // to Visualize. The index distinguishes which Knob, Note, or Program
-            // button was involved. Note that when pressing and releasing a Note, two
-            // events will be created. The first will be issued when the note is
-            // pressed, and its value will be the non-zero velocity with which the
-            // press occurred. The second will be issued when the note is released,
-            // and its value will be zero.
-            // public enum MidiCommandType : byte { Knob, Note, Program }
-            // public struct MidiCommand {
-            //   public int deviceIndex;
-            //   public MidiCommandType type;
-            //   public int index;
-            //   public double value;
-            // }
-            MidiCommand[] midiCommandsSinceLastTick =
-              this.midi.GetCommandsSinceLastTick();
-
-            //-----------------------------------------------------------------------
-            // COLORS
-            //-----------------------------------------------------------------------
-
-            // Notes on colors:
-            // (1) We represent colors using RGB values stored as ints. Each int
-            //     consists of three concatenated bytes (red, green, and blue).
-            // (2) These RGB values should not be thought of in the same way as RGB
-            //     values in CSS or HTML. The important distinction is that point LEDs
-            //     cannot display composite colors such as brown and pink. Each LED
-            //     can only display a single wavelength of light at a given moment.
-            // (3) An easy way to imagine how a given RGB value will look: scale each
-            //     component (red, green, and blue) up equally until at least one of
-            //     the components is maxed out at 255. The scale factor represents the
-            //     brightness, and the scaled-up color is what you will see on the
-            //     LED. SimulatorUtils.GetComputerColor can take an RGB int and return
-            //     the scaled-up color.
-            // (4) The VJ is able to configure 8 distinct color palettes, each
-            //     consisting of 8 pairs of colors. Each pair represents a gradient,
-            //     meaning that for each color palette, the VJ has 16 color inputs.
-            // (5) By calling the methods below on this.dome instead of on
-            //     this.config.colorPalette, we make sure that the brightness is
-            //     scaled according to Spectrum's config. We never run the dome at
-            //     100% brightness, and our power supplies are not provisioned for it.
-
-            // GetSingleColor retrieves the color pair at the given index for the
-            // current color palette. It then discards the second color in the pair,
-            // returning only the first color in the pair.
-            int firstSingleColor = this.dome.GetSingleColor(0);
-
-            // GetGradientColor is a bit more complicated. It retrieves the color pair
-            // at the given index for the current color palette, and then blends that
-            // pair according to the rest of the parameters.
-            // Imagine a strut that is being colored according to a gradient.
-            // (*) The second parameter (0.5 below) is a double from 0.0 to 1.0 that
-            //     represents the position along that strut. So ignoring the last two
-            //     parameters, the second parameter will determine how much of each
-            //     color to mix. 0.5 means half of each, whereas 0.0 means just the
-            //     first color, and 1.0 means just the second color.
-            // (*) The third parameter (0.0 below) is a double from 0.0 to 1.0 that
-            //     represents an offset we add to the second parameter. Its purpose is
-            //     to allow the Visualizer author to animate the gradient along a
-            //     strut. If you set it to 0.25, then the LED one quarter of the way
-            //     through the strut will be the first color, and the one right before
-            //     it will be the second color. Correspondingly, the first LED on the
-            //     strut would be 75% second color, 25% first color.
-            // (*) The final parameter (false below) is a boolean that represents
-            //     whether we want the gradient to "wrap" or not. If you set this to
-            //     true, in the above case where the third parameter is 0.25, instead
-            //     of seeing a sharp transition a quarter of the way in, the gradient
-            //     will be represented all the way through. In the 0.25 case, the LED
-            //     one quarter of the way in would be the first color, and the LED
-            //     three quarters of the way in would be the second color. The first
-            //     LED as well as the last LED on the strut would both be a 50/50
-            //     blend.
-            int middleOfStrutColor = this.dome.GetGradientColor(0, 0.5, 0.0, false);
-
-            //-----------------------------------------------------------------------
-            // STRUT LAYOUTS
-            //-----------------------------------------------------------------------
-
-            // Notes on strut layout:
-            // (1) Each LED on the dome is uniquely identified by a pair of a strut
-            //     index and an LED index.
-            // (2) The "key" that shows how strut indices are assigned can be viewed
-            //     in the dome simulator window. To open the dome simulator window,
-            //     first run Spectrum, then go to the "LED Dome" tab and check the box
-            //     labelled "Simulate". The simulator window should pop up. Click
-            //     "Show Key" to see the key.
-            // (3) Each strut has a number of LEDs, as well as a direction that
-            //     determines how its LED indices are assigned. The key provides this
-            //     information.
-            // (4) If you want to create a list of struts that you want to animate
-            //     together, you can press a series of struts in the key view. The
-            //     text box on the upper right will populate with a comma-separated
-            //     list of strut indices.
-
-            // StrutLayoutFactory contains utilities for generating collections of
-            // Struts, known as StrutLayouts.
-            // (*) The Strut class simply represents a strut by a given strut index,
-            //     as well as including a boolean for whether or not to reverse the
-            //     direction.
-            // (*) The StrutLayoutSegment class represents an unordered set of Struts.
-            //     There is no order within a StrutLayoutSegment, as all the Struts
-            //     within are expected to be animated together, at the same time.
-            // (*) A StrutLayout is simply an array of StrutLayoutSegments.
-            // (*) StrutLayoutFactory also assigns each vertex an index (calling them
-            //     "points"), which it uses in certain cases as user inputs.
-
-            // If you've ever seen the default dome animation in past years, it's
-            // basically using this layout. It's pretty domain-specific, and probably
-            // not worth getting into too much. You won't be calling this method, but
-            // if you're finding yourself making a complex strut layout, you might end
-            // up writing someting similar.
-            StrutLayout[] layouts = StrutLayoutFactory.ConcentricFromStartingPoints(
-              this.config,
-              // This list of points was determined manually
-              new HashSet<int>(new int[] { 22, 26, 30, 34, 38, 70 }),
-              4
-            );
-
-            //-----------------------------------------------------------------------
-            // SETTING LEDS
-            //-----------------------------------------------------------------------
-
-            // This method is used to set an LED to a color. You identify the LED
-            // using a pair of a strut index and an LED index (see STRUT LAYOUTS
-            // above), and then provide a color to set that LED to.
-            this.dome.SetPixel(15, 20, firstSingleColor);
-            for (int i = 0; i < LEDDomeOutput.GetNumStruts(); i++) {
-                Strut strut = Strut.FromIndex(this.config, i);
-                var leds = LEDDomeOutput.GetNumLEDs(i);
-                for (int j = 0; j < leds; j++) {
-                    var pixel_p = StrutLayoutFactory.GetProjectedLEDPointParametric(i, j);
-                }
-            }
-
-            // No messages will be sent to the Beaglebone until Flush is called. This
-            // makes it imperative that you call Flush at the end of Visualize, or
-            // whenever you want to update the LEDs. The LEDs themselves are stateful,
-            // and will maintain whatever color you set them to until they lose power.
-            this.dome.Flush();
-        }
-
+      // No messages will be sent to the Beaglebone until Flush is called. This
+      // makes it imperative that you call Flush at the end of Visualize, or
+      // whenever you want to update the LEDs. The LEDs themselves are stateful,
+      // and will maintain whatever color you set them to until they lose power.
+      this.dome.Flush();
     }
+
+  }
 
 }

--- a/Spectrum/Visualizers/LEDDomeRaceVisualizer.cs
+++ b/Spectrum/Visualizers/LEDDomeRaceVisualizer.cs
@@ -5,11 +5,9 @@ using Spectrum.LEDs;
 using System;
 using System.Collections.Generic;
 
-namespace Spectrum
-{
+namespace Spectrum {
 
-  class LEDDomeRaceVisualizer : Visualizer
-  {
+  class LEDDomeRaceVisualizer : Visualizer {
     /**
      * Visualizes spinning bands (racers) going around the dome. Each moves at a speed proportional 
      * to volume, beats, constant, or still. See RacerConfig below to configure the bands.
@@ -18,7 +16,7 @@ namespace Spectrum
     private readonly AudioInput audio;
     private readonly MidiInput midi;
     private readonly LEDDomeOutput dome;
- 
+
     public enum Rotation { Still, Constant, Volume, VolumeSquared, Beat, };
     public enum Size { Small, Medium, Large, Full };
     public enum Coloring { Constant, Fade, FadeExp, Multi };
@@ -32,7 +30,7 @@ namespace Spectrum
         coloring = c;
       }
     }
-    
+
     /**
      * The Configuration Settings. Each item is an can add as many bands as you would like.
      * The first will always be closest to the ground, and the last will be at the north pole.
@@ -40,7 +38,7 @@ namespace Spectrum
      * Size: How large will it be, small, medium, large, or full (complete circle)
      * Coloring: How it will be colored, multiple colors, fading out, expoenential fade out, or constant.
      */
-    public RacerConfig[] racerConfig = { 
+    public RacerConfig[] racerConfig = {
       new RacerConfig(Rotation.VolumeSquared, Size.Full, Coloring.Multi),
       new RacerConfig(Rotation.VolumeSquared, Size.Medium, Coloring.FadeExp),
       new RacerConfig(Rotation.Beat, Size.Small, Coloring.FadeExp),
@@ -52,44 +50,45 @@ namespace Spectrum
     // 0 means right next to eachother. 1 means they have a size of 0.
     private double racer_spacing = 0;
 
-    private class Racer
-    {
+    private class Racer {
       public double Y { get; protected set; }  // Location in height 1 is top, 0 is bottom.
       public double Angle { get; protected set; } // Location of the Racer in Radians, -pi to pi
       public double Radians { get; protected set; } // Length of the Racer in Radians, 0 to 2*pi
       private int idx; // Length of the Racer in Radians, 0 to 2*pi
       private double AccumulatedSeconds;
       private RacerConfig conf;
-      public Racer(int idx, int num_racers, RacerConfig racer_config)
-      {
+      public Racer(int idx, int num_racers, RacerConfig racer_config) {
         conf = racer_config;
-        double width = conf.size == Size.Small ? 1.0 / 8: 
-          conf.size == Size.Medium ? 1.0 / 4:
-          conf.size == Size.Large ? 3.0 / 4:
+        double width = conf.size == Size.Small ? 1.0 / 8 :
+          conf.size == Size.Medium ? 1.0 / 4 :
+          conf.size == Size.Large ? 3.0 / 4 :
           1;
         this.Y = 1.0 * idx / num_racers + .5;
         this.Angle = 0;
-        this.Radians = 2*Math.PI * width;
+        this.Radians = 2 * Math.PI * width;
         AccumulatedSeconds = 0;
       }
       public void Move(double numSeconds, AudioInput audio, Configuration config) {
         // Could use classes for this, but eh.
-        double revsPerSec = 
-          conf.rotation == Rotation.Volume ? RevsPerSecondVolume(audio, config):
-          conf.rotation == Rotation.VolumeSquared ? RevsPerSecondVolumeSquared(audio, config):
-          conf.rotation == Rotation.Beat ? RevsPerSecondBeats(audio, config):
-          conf.rotation == Rotation.Constant ? RevsPerSecondConstant(audio, config):
+        double revsPerSec =
+          conf.rotation == Rotation.Volume ? RevsPerSecondVolume(audio, config) :
+          conf.rotation == Rotation.VolumeSquared ? RevsPerSecondVolumeSquared(audio, config) :
+          conf.rotation == Rotation.Beat ? RevsPerSecondBeats(audio, config) :
+          conf.rotation == Rotation.Constant ? RevsPerSecondConstant(audio, config) :
           0;
         double radsPerSecond = Math.PI * 2 * revsPerSec;
         MoveRads(numSeconds, radsPerSecond);
       }
       public int Color(LEDDomeOutput dome, Configuration config, double loc_y, double loc_ang) {
-        if(conf.coloring == Coloring.Fade) {
-          return dome.GetSingleColor(this.idx, loc_ang);
-        } else if(conf.coloring == Coloring.FadeExp) {
-          var s = 4*loc_ang - 4;
-          return dome.GetSingleColor(this.idx, 1.0 / (1 + Math.Pow(Math.E, -s)));
-        } else if(conf.coloring == Coloring.Multi) {
+        if (conf.coloring == Coloring.Fade) {
+          return LEDColor.ScaleColor(dome.GetSingleColor(this.idx), loc_ang);
+        } else if (conf.coloring == Coloring.FadeExp) {
+          var s = 4 * loc_ang - 4;
+          return LEDColor.ScaleColor(
+            dome.GetSingleColor(this.idx),
+            1.0 / (1 + Math.Pow(Math.E, -s))
+         );
+        } else if (conf.coloring == Coloring.Multi) {
           var end_index = config.colorPalette.colors.Length - 1;
           return dome.GetGradientBetweenColors(end_index - 4, end_index, loc_ang, 0.0, false);
         }
@@ -98,15 +97,15 @@ namespace Spectrum
 
       private void MoveRads(double numSeconds, double radsPerSecond) {
         double rads = (numSeconds + AccumulatedSeconds) * radsPerSecond;
-        if(rads < .0001) {
+        if (rads < .0001) {
           // If radians are too small, we may not have enough precision to move anything.
           // Instead, accumulate the movement and try next time.
           AccumulatedSeconds += numSeconds;
           return;
         }
         Angle += rads;
-        if(Angle > Math.PI) {
-          Angle -= Math.PI*2;
+        if (Angle > Math.PI) {
+          Angle -= Math.PI * 2;
         }
         AccumulatedSeconds = 0;
       }
@@ -119,11 +118,11 @@ namespace Spectrum
         return audio.Volume * audio.Volume + config.domeVolumeRotationSpeed / 12;
       }
       public double RevsPerSecondBeats(AudioInput audio, Configuration config) {
-        if(config.beatBroadcaster.MeasureLength == -1) {
-          return 0;
-        }
-        // Taken from the BPM toString method, and multiply by 60 for seconds.
-        double BPS = 1000.0 / config.beatBroadcaster.MeasureLength;
+        double BPS =
+          // If we don't have a beet counter, fake it as 60 BPM.
+          config.beatBroadcaster.MeasureLength == -1 ? 1 :
+          // Taken from the BPM toString method, and multiply by 60 for seconds.
+          1000.0 / config.beatBroadcaster.MeasureLength;
         // Make a full revolution after 4 beats.
         return 1.0 * BPS / 4;
       }
@@ -134,42 +133,42 @@ namespace Spectrum
 
     private Racer[] Racers { get; set; }
     private long lastTicks { get; set; }
-    
+
     private Tuple<Racer, double, double, Racer> GetRacer(double Y, double ang) {
       // e.g., say 2 racers, racer0 centered on .25; racer1 centered on .75.
       // Y = .4. We should return the first racer if in spacing.
-      if(Y > .9999) {
-         Y = .9999;
+      if (Y > .9999) {
+        Y = .9999;
       }
       double racer_loc_y = Y * racerConfig.Length; // Scale from 0 to num_racers
       int racer_idx = (int)(racer_loc_y);
       racer_loc_y -= racer_idx; // Scale from 0 to 1, same as  
       racer_loc_y -= .5; // Scale from -.5 to .5
       racer_loc_y = Math.Abs(racer_loc_y);
-      if(racer_loc_y > racer_spacing) {
+      if (racer_loc_y > racer_spacing) {
         return null;
       }
       Racer r = this.Racers[racer_idx];
       // Offset is how many radians ahead of the start angle.
       double start_angle = r.Angle;
-      if(start_angle < 0) {
-        start_angle += 2*Math.PI;
+      if (start_angle < 0) {
+        start_angle += 2 * Math.PI;
       }
-      if(ang < 0) {
-        ang += 2*Math.PI;
+      if (ang < 0) {
+        ang += 2 * Math.PI;
       }
       double offset = ang - start_angle;
-      if(offset < 0) {
-        offset += Math.PI*2;
+      if (offset < 0) {
+        offset += Math.PI * 2;
       }
-      if(offset < 2*Math.PI - r.Radians) {
+      if (offset < 2 * Math.PI - r.Radians) {
         return null;
       }
       // Some more manipulation to get the percentage in the range
       //   offset > 2*Math.PI - r.Radians
       //   r.Radians > 2*Math.PI - offset
       //   1 > (2*Math.PI - offset) / r.Radians
-      double racer_loc_ang = 1 - (2*Math.PI - offset) / r.Radians;
+      double racer_loc_ang = 1 - (2 * Math.PI - offset) / r.Radians;
       return new Tuple<Racer, double, double, Racer>(r, racer_loc_y, racer_loc_ang, r);
     }
 
@@ -178,8 +177,7 @@ namespace Spectrum
      AudioInput audio,
      MidiInput midi,
      LEDDomeOutput dome
-     )
-    {
+     ) {
       this.config = config;
       this.audio = audio;
       this.midi = midi;
@@ -197,15 +195,12 @@ namespace Spectrum
       this.dome.RegisterVisualizer(this);
     }
 
-    public int Priority
-    {
-      get
-      {
+    public int Priority {
+      get {
         // The mapping between Visualizers and their corresponding domeActiveVis
         // integer value is determined in the condition below, as well as in the
         // Bind call for domeActiveVis in MainWindow.xaml.cs
-        if (this.config.domeActiveVis != 2)
-        {
+        if (this.config.domeActiveVis != 2) {
           // By setting the priority to 0, we guarantee that this Visualizer
           // will not run
           return 0;
@@ -215,8 +210,7 @@ namespace Spectrum
         // that Visualizer when there is no audio input. If you are writing a
         // Visualizer that depends on audio input, consider disabling it when
         // the audio is off using the following condition:
-        if (this.audio.isQuiet)
-        {
+        if (this.audio.isQuiet) {
           return 0;
         }
         // You can return any number higher than 1 here to make sure this
@@ -237,16 +231,12 @@ namespace Spectrum
     // Otherwise, if you want to do something special either when being enabled
     // or disabled, use the following code:
     private bool enabled = false;
-    public bool Enabled
-    {
-      get
-      {
+    public bool Enabled {
+      get {
         return this.enabled;
       }
-      set
-      {
-        if (value == this.enabled)
-        {
+      set {
+        if (value == this.enabled) {
           return;
         }
         // Any code that you want to run when the Visualizer is enabled or when
@@ -255,8 +245,7 @@ namespace Spectrum
       }
     }
 
-    public Input[] GetInputs()
-    {
+    public Input[] GetInputs() {
       // In order for the Operator to know which Inputs need to be enabled, you
       // should return the ones you are currently using here. If your Visualizer
       // only needs certain Inputs under certain conditions, you can put
@@ -267,24 +256,7 @@ namespace Spectrum
     // This is where the magic happens. As long as this Visualizer has the
     // highest priority for LEDDomeOutput, the Operator thread will call
     // Visualize once per tick
-    public void Visualize()
-    {
-
-      //-----------------------------------------------------------------------
-      // TRACKING THE BEAT
-      //-----------------------------------------------------------------------
-
-      // progressThroughMeasure is a double from 0.0 to 1.0 that represents the
-      // progress through the current musical measure at this instant in time
-      double progressThroughMeasure =
-        this.config.beatBroadcaster.ProgressThroughMeasure;
-
-      // ProgressThroughBeat can be used to get the progress through any
-      // multiple of a musical measure. Note that the measure is DIVIDED by the
-      // parameter you pass to ProgressThroughBeat, so eg. if you want the
-      // return value to hit 1.0 on every quarter note, you should pass in 4.0
-      double progressThroughHalfMeasure =
-        this.config.beatBroadcaster.ProgressThroughBeat(2.0);
+    public void Visualize() {
 
       //-----------------------------------------------------------------------
       // TRACKING THE LEVEL (VOLUME)
@@ -293,70 +265,6 @@ namespace Spectrum
       // volume is a float from 0.0 to 1.0 that represents the current total
       // output "level", aka volume
       float volume = this.audio.Volume;
-
-      // The VJ has the ability to configure a "channel" that represents the
-      // level within a specific frequency range. They can configure up to 8
-      // distinct channels. Besides configuring a frequency range applied to the
-      // audio input, it is also possible for the VJ to associate a channel with
-      // a MIDI note coming from a MIDI input. In general, it's probably better
-      // to use channel0Level instead of Volume, since it gives the VJ more
-      // flexibility to configure the Visualizer. Channel 0 is usually
-      // configured to be the same as Volume
-      double channel0Level = this.audio.LevelForChannel(0);
-
-      //-----------------------------------------------------------------------
-      // RESPONDING TO A KICK OR SNARE
-      //-----------------------------------------------------------------------
-
-      // An AudioEvent is queued up when Spectrum detects either a Kick or a
-      // Snare. On every call to Visualize, audioEventsSinceLastTick will
-      // contain a list of detected Kick or Snare events that have occured since
-      // the last call to Visualize.
-      // public enum AudioDetectorType : byte { Kick, Snare }
-      // public class AudioEvent {
-      //   public AudioDetectorType type;
-      //   public double significance;
-      // }
-      List<AudioEvent> audioEventsSinceLastTick =
-        this.audio.GetEventsSinceLastTick();
-
-      //-----------------------------------------------------------------------
-      // MIDI DEVICES
-      //-----------------------------------------------------------------------
-
-      // knobValue is a double from 0.0 to 1.0 that represents the current
-      // state of knob #15 on MIDI device #0. You can assume that the active
-      // MIDI deviceIndex is always 0. Which knob corresponds to #15 will depend
-      // on the MIDI board in question.
-      double knobValue = this.midi.GetKnobValue(0, 15);
-
-      // noteVelocity is a double from 0.0 to 1.0 that represents the velocity
-      // with which note #15 on MIDI device #0 was hit. The velocity is set to a
-      // non-zero value when the note is pressed, and is reset to zero when the
-      // note is released. If noteVelocity is non-zero, that means the note in
-      // question is currently depressed. You can assume that the active MIDI
-      // deviceIndex is always 0. Which note corresponds to #15 will depend on
-      // the MIDI board in question.
-      double noteVelocity = this.midi.GetNoteVelocity(0, 15);
-
-      // An MidiCommand is queued up whenever input is detected from a MIDI
-      // device. On every call to Visualize, midiCommandsSinceLastTick will
-      // contain an array of MIDI events that have occured since the last call
-      // to Visualize. The index distinguishes which Knob, Note, or Program
-      // button was involved. Note that when pressing and releasing a Note, two
-      // events will be created. The first will be issued when the note is
-      // pressed, and its value will be the non-zero velocity with which the
-      // press occurred. The second will be issued when the note is released,
-      // and its value will be zero.
-      // public enum MidiCommandType : byte { Knob, Note, Program }
-      // public struct MidiCommand {
-      //   public int deviceIndex;
-      //   public MidiCommandType type;
-      //   public int index;
-      //   public double value;
-      // }
-      MidiCommand[] midiCommandsSinceLastTick =
-        this.midi.GetCommandsSinceLastTick();
 
       //-----------------------------------------------------------------------
       // COLORS
@@ -383,49 +291,17 @@ namespace Spectrum
       //   scaled according to Spectrum's config. We never run the dome at
       //   100% brightness, and our power supplies are not provisioned for it.
 
-      // GetSingleColor retrieves the color pair at the given index for the
-      // current color palette. It then discards the second color in the pair,
-      // returning only the first color in the pair.
-      int firstSingleColor = this.dome.GetSingleColor(0);
-
-      // GetGradientColor is a bit more complicated. It retrieves the color pair
-      // at the given index for the current color palette, and then blends that
-      // pair according to the rest of the parameters.
-      // Imagine a strut that is being colored according to a gradient.
-      // (*) The second parameter (0.5 below) is a double from 0.0 to 1.0 that
-      //   represents the position along that strut. So ignoring the last two
-      //   parameters, the second parameter will determine how much of each
-      //   color to mix. 0.5 means half of each, whereas 0.0 means just the
-      //   first color, and 1.0 means just the second color.
-      // (*) The third parameter (0.0 below) is a double from 0.0 to 1.0 that
-      //   represents an offset we add to the second parameter. Its purpose is
-      //   to allow the Visualizer author to animate the gradient along a
-      //   strut. If you set it to 0.25, then the LED one quarter of the way
-      //   through the strut will be the first color, and the one right before
-      //   it will be the second color. Correspondingly, the first LED on the
-      //   strut would be 75% second color, 25% first color.
-      // (*) The final parameter (false below) is a boolean that represents
-      //   whether we want the gradient to "wrap" or not. If you set this to
-      //   true, in the above case where the third parameter is 0.25, instead
-      //   of seeing a sharp transition a quarter of the way in, the gradient
-      //   will be represented all the way through. In the 0.25 case, the LED
-      //   one quarter of the way in would be the first color, and the LED
-      //   three quarters of the way in would be the second color. The first
-      //   LED as well as the last LED on the strut would both be a 50/50
-      //   blend.
-      int middleOfStrutColor = this.dome.GetGradientColor(0, 0.5, 0.0, false);
-      
       //-----------------------------------------------------------------------
       // SETTING THE RACERS
       //-----------------------------------------------------------------------
-      
-      this.racer_spacing = this.config.domeRadialSize / 4.0;
+
+      this.racer_spacing = this.config.domeRadialSize > 1 ? 1.0 : this.config.domeRadialSize;
       var curTicks = DateTime.Now.Ticks;
-      if(this.lastTicks == -1) { 
+      if (this.lastTicks == -1) {
         this.lastTicks = curTicks;
-      } else { 
+      } else {
         double numSeconds = ((double)(curTicks - this.lastTicks)) / (1000 * 1000 * 10);
-        foreach(Racer r in Racers) {
+        foreach (Racer r in Racers) {
           r.Move(numSeconds, audio, config);
         }
         this.lastTicks = curTicks;
@@ -435,10 +311,6 @@ namespace Spectrum
       // SETTING LEDS
       //-----------------------------------------------------------------------
 
-      // This method is used to set an LED to a color. You identify the LED
-      // using a pair of a strut index and an LED index (see STRUT LAYOUTS
-      // above), and then provide a color to set that LED to.
-      this.dome.SetPixel(15, 20, firstSingleColor);
       for (int i = 0; i < LEDDomeOutput.GetNumStruts(); i++) {
         Strut strut = Strut.FromIndex(this.config, i);
         var leds = LEDDomeOutput.GetNumLEDs(i);
@@ -448,7 +320,7 @@ namespace Spectrum
           var y = 1.0 - pixel_p.Item4;
           var rad = pixel_p.Item3;
           Tuple<Racer, double, double, Racer> loc = this.GetRacer(y, rad);
-          if(loc == null) {
+          if (loc == null) {
             // color = 0 is off.
             this.dome.SetPixel(i, j, 0);
           } else {
@@ -465,7 +337,5 @@ namespace Spectrum
       // and will maintain whatever color you set them to until they lose power.
       this.dome.Flush();
     }
-
   }
-
 }

--- a/Spectrum/Visualizers/LEDDomeRaceVisualizer.cs
+++ b/Spectrum/Visualizers/LEDDomeRaceVisualizer.cs
@@ -1,0 +1,350 @@
+﻿using Spectrum.Base;
+using Spectrum.Audio;
+using Spectrum.MIDI;
+using Spectrum.LEDs;
+using System.Collections.Generic;
+
+namespace Spectrum
+{
+
+    class LEDDomeRaceVisualizer : Visualizer
+    {
+
+        private readonly Configuration config;
+        private readonly AudioInput audio;
+        private readonly MidiInput midi;
+        private readonly LEDDomeOutput dome;
+        
+        // How much spacing should be in between each racer. 
+        // Determines racer size. 
+        // 0 means right next to eachother. 1 means they have a size of 0.
+        private static readonly double racer_spacing = .3;
+
+        private class Racer
+        {
+            public double Y { get; set; }
+            public double Radians { get; set; }
+            public double Height { get; set; }
+            public Racer(int idx, int num_racers)
+            {
+                this.Y = 1.0 * idx / num_racers;
+                this.Radians = 0;
+                this.Height = 1.0 * racer_spacing / num_racers;
+            }
+        }
+
+        private Racer[] Racers { get; set; }
+        private long lastTicks { get; set; }
+
+        public LEDDomeRaceVisualizer(
+         Configuration config,
+         AudioInput audio,
+         MidiInput midi,
+         LEDDomeOutput dome
+       )
+        {
+            this.config = config;
+            this.audio = audio;
+            this.midi = midi;
+            this.dome = dome;
+            // Create new racers.
+            int num_racers = this.config.domeVolumeAnimationSize;
+            this.Racers = new Racer[num_racers];
+            for (int i = 0; i < this.config.domeVolumeAnimationSize; i++) {
+              this.Racers[i] = new Racer(i, num_racers);
+            }
+            this.lastTicks = -1;
+            // This call is necessary to make sure the Operator considers this
+            // Visualizer when comparing priorities for LEDDomeOutput. If you skip it
+            // your Visualizer will never run
+            this.dome.RegisterVisualizer(this);
+        }
+
+        public int Priority
+        {
+            get
+            {
+                // The mapping between Visualizers and their corresponding domeActiveVis
+                // integer value is determined in the condition below, as well as in the
+                // Bind call for domeActiveVis in MainWindow.xaml.cs
+                if (this.config.domeActiveVis != 3)
+                {
+                    // By setting the priority to 0, we guarantee that this Visualizer
+                    // will not run
+                    return 0;
+                }
+                // There is a "screensaver" Visualizer with priority 1 associated with
+                // LEDDomeOutput (LEDDomeTVStaticVisualizer). The intention is to run
+                // that Visualizer when there is no audio input. If you are writing a
+                // Visualizer that depends on audio input, consider disabling it when
+                // the audio is off using the following condition:
+                if (this.audio.isQuiet)
+                {
+                    return 0;
+                }
+                // You can return any number higher than 1 here to make sure this
+                // Visualizer runs and the screensaver Visualizer doesn't
+                return 2;
+            }
+        }
+
+        // When the Operator determines that this Visualizer has the highest
+        // priority for LEDDomeOutput, it will set the Enabled property below to
+        // true. Conversely, when it determines that this Visualizer no longer has
+        // the highest priority, it will set it to false. Note that the Visualize
+        // method below will be called if and only if Enabled is set to true.
+
+        // If you don't need to do any sort of preparation when your Visualizer is
+        // enabled, you can just use the following line to define the property:
+        // public bool Enabled { get; set; }
+        // Otherwise, if you want to do something special either when being enabled
+        // or disabled, use the following code:
+        private bool enabled = false;
+        public bool Enabled
+        {
+            get
+            {
+                return this.enabled;
+            }
+            set
+            {
+                if (value == this.enabled)
+                {
+                    return;
+                }
+                // Any code that you want to run when the Visualizer is enabled or when
+                // it's disabled should go here
+                this.enabled = value;
+            }
+        }
+
+        public Input[] GetInputs()
+        {
+            // In order for the Operator to know which Inputs need to be enabled, you
+            // should return the ones you are currently using here. If your Visualizer
+            // only needs certain Inputs under certain conditions, you can put
+            // conditional logic here
+            return new Input[] { this.audio, this.midi };
+        }
+
+        // This is where the magic happens. As long as this Visualizer has the
+        // highest priority for LEDDomeOutput, the Operator thread will call
+        // Visualize once per tick
+        public void Visualize()
+        {
+
+            //-----------------------------------------------------------------------
+            // TRACKING THE BEAT
+            //-----------------------------------------------------------------------
+
+            // progressThroughMeasure is a double from 0.0 to 1.0 that represents the
+            // progress through the current musical measure at this instant in time
+            double progressThroughMeasure =
+              this.config.beatBroadcaster.ProgressThroughMeasure;
+
+            // ProgressThroughBeat can be used to get the progress through any
+            // multiple of a musical measure. Note that the measure is DIVIDED by the
+            // parameter you pass to ProgressThroughBeat, so eg. if you want the
+            // return value to hit 1.0 on every quarter note, you should pass in 4.0
+            double progressThroughHalfMeasure =
+              this.config.beatBroadcaster.ProgressThroughBeat(2.0);
+
+            //-----------------------------------------------------------------------
+            // TRACKING THE LEVEL (VOLUME)
+            //-----------------------------------------------------------------------
+
+            // volume is a float from 0.0 to 1.0 that represents the current total
+            // output "level", aka volume
+            float volume = this.audio.Volume;
+
+            // The VJ has the ability to configure a "channel" that represents the
+            // level within a specific frequency range. They can configure up to 8
+            // distinct channels. Besides configuring a frequency range applied to the
+            // audio input, it is also possible for the VJ to associate a channel with
+            // a MIDI note coming from a MIDI input. In general, it's probably better
+            // to use channel0Level instead of Volume, since it gives the VJ more
+            // flexibility to configure the Visualizer. Channel 0 is usually
+            // configured to be the same as Volume
+            double channel0Level = this.audio.LevelForChannel(0);
+
+            //-----------------------------------------------------------------------
+            // RESPONDING TO A KICK OR SNARE
+            //-----------------------------------------------------------------------
+
+            // An AudioEvent is queued up when Spectrum detects either a Kick or a
+            // Snare. On every call to Visualize, audioEventsSinceLastTick will
+            // contain a list of detected Kick or Snare events that have occured since
+            // the last call to Visualize.
+            // public enum AudioDetectorType : byte { Kick, Snare }
+            // public class AudioEvent {
+            //   public AudioDetectorType type;
+            //   public double significance;
+            // }
+            List<AudioEvent> audioEventsSinceLastTick =
+              this.audio.GetEventsSinceLastTick();
+
+            //-----------------------------------------------------------------------
+            // MIDI DEVICES
+            //-----------------------------------------------------------------------
+
+            // knobValue is a double from 0.0 to 1.0 that represents the current
+            // state of knob #15 on MIDI device #0. You can assume that the active
+            // MIDI deviceIndex is always 0. Which knob corresponds to #15 will depend
+            // on the MIDI board in question.
+            double knobValue = this.midi.GetKnobValue(0, 15);
+
+            // noteVelocity is a double from 0.0 to 1.0 that represents the velocity
+            // with which note #15 on MIDI device #0 was hit. The velocity is set to a
+            // non-zero value when the note is pressed, and is reset to zero when the
+            // note is released. If noteVelocity is non-zero, that means the note in
+            // question is currently depressed. You can assume that the active MIDI
+            // deviceIndex is always 0. Which note corresponds to #15 will depend on
+            // the MIDI board in question.
+            double noteVelocity = this.midi.GetNoteVelocity(0, 15);
+
+            // An MidiCommand is queued up whenever input is detected from a MIDI
+            // device. On every call to Visualize, midiCommandsSinceLastTick will
+            // contain an array of MIDI events that have occured since the last call
+            // to Visualize. The index distinguishes which Knob, Note, or Program
+            // button was involved. Note that when pressing and releasing a Note, two
+            // events will be created. The first will be issued when the note is
+            // pressed, and its value will be the non-zero velocity with which the
+            // press occurred. The second will be issued when the note is released,
+            // and its value will be zero.
+            // public enum MidiCommandType : byte { Knob, Note, Program }
+            // public struct MidiCommand {
+            //   public int deviceIndex;
+            //   public MidiCommandType type;
+            //   public int index;
+            //   public double value;
+            // }
+            MidiCommand[] midiCommandsSinceLastTick =
+              this.midi.GetCommandsSinceLastTick();
+
+            //-----------------------------------------------------------------------
+            // COLORS
+            //-----------------------------------------------------------------------
+
+            // Notes on colors:
+            // (1) We represent colors using RGB values stored as ints. Each int
+            //     consists of three concatenated bytes (red, green, and blue).
+            // (2) These RGB values should not be thought of in the same way as RGB
+            //     values in CSS or HTML. The important distinction is that point LEDs
+            //     cannot display composite colors such as brown and pink. Each LED
+            //     can only display a single wavelength of light at a given moment.
+            // (3) An easy way to imagine how a given RGB value will look: scale each
+            //     component (red, green, and blue) up equally until at least one of
+            //     the components is maxed out at 255. The scale factor represents the
+            //     brightness, and the scaled-up color is what you will see on the
+            //     LED. SimulatorUtils.GetComputerColor can take an RGB int and return
+            //     the scaled-up color.
+            // (4) The VJ is able to configure 8 distinct color palettes, each
+            //     consisting of 8 pairs of colors. Each pair represents a gradient,
+            //     meaning that for each color palette, the VJ has 16 color inputs.
+            // (5) By calling the methods below on this.dome instead of on
+            //     this.config.colorPalette, we make sure that the brightness is
+            //     scaled according to Spectrum's config. We never run the dome at
+            //     100% brightness, and our power supplies are not provisioned for it.
+
+            // GetSingleColor retrieves the color pair at the given index for the
+            // current color palette. It then discards the second color in the pair,
+            // returning only the first color in the pair.
+            int firstSingleColor = this.dome.GetSingleColor(0);
+
+            // GetGradientColor is a bit more complicated. It retrieves the color pair
+            // at the given index for the current color palette, and then blends that
+            // pair according to the rest of the parameters.
+            // Imagine a strut that is being colored according to a gradient.
+            // (*) The second parameter (0.5 below) is a double from 0.0 to 1.0 that
+            //     represents the position along that strut. So ignoring the last two
+            //     parameters, the second parameter will determine how much of each
+            //     color to mix. 0.5 means half of each, whereas 0.0 means just the
+            //     first color, and 1.0 means just the second color.
+            // (*) The third parameter (0.0 below) is a double from 0.0 to 1.0 that
+            //     represents an offset we add to the second parameter. Its purpose is
+            //     to allow the Visualizer author to animate the gradient along a
+            //     strut. If you set it to 0.25, then the LED one quarter of the way
+            //     through the strut will be the first color, and the one right before
+            //     it will be the second color. Correspondingly, the first LED on the
+            //     strut would be 75% second color, 25% first color.
+            // (*) The final parameter (false below) is a boolean that represents
+            //     whether we want the gradient to "wrap" or not. If you set this to
+            //     true, in the above case where the third parameter is 0.25, instead
+            //     of seeing a sharp transition a quarter of the way in, the gradient
+            //     will be represented all the way through. In the 0.25 case, the LED
+            //     one quarter of the way in would be the first color, and the LED
+            //     three quarters of the way in would be the second color. The first
+            //     LED as well as the last LED on the strut would both be a 50/50
+            //     blend.
+            int middleOfStrutColor = this.dome.GetGradientColor(0, 0.5, 0.0, false);
+
+            //-----------------------------------------------------------------------
+            // STRUT LAYOUTS
+            //-----------------------------------------------------------------------
+
+            // Notes on strut layout:
+            // (1) Each LED on the dome is uniquely identified by a pair of a strut
+            //     index and an LED index.
+            // (2) The "key" that shows how strut indices are assigned can be viewed
+            //     in the dome simulator window. To open the dome simulator window,
+            //     first run Spectrum, then go to the "LED Dome" tab and check the box
+            //     labelled "Simulate". The simulator window should pop up. Click
+            //     "Show Key" to see the key.
+            // (3) Each strut has a number of LEDs, as well as a direction that
+            //     determines how its LED indices are assigned. The key provides this
+            //     information.
+            // (4) If you want to create a list of struts that you want to animate
+            //     together, you can press a series of struts in the key view. The
+            //     text box on the upper right will populate with a comma-separated
+            //     list of strut indices.
+
+            // StrutLayoutFactory contains utilities for generating collections of
+            // Struts, known as StrutLayouts.
+            // (*) The Strut class simply represents a strut by a given strut index,
+            //     as well as including a boolean for whether or not to reverse the
+            //     direction.
+            // (*) The StrutLayoutSegment class represents an unordered set of Struts.
+            //     There is no order within a StrutLayoutSegment, as all the Struts
+            //     within are expected to be animated together, at the same time.
+            // (*) A StrutLayout is simply an array of StrutLayoutSegments.
+            // (*) StrutLayoutFactory also assigns each vertex an index (calling them
+            //     "points"), which it uses in certain cases as user inputs.
+
+            // If you've ever seen the default dome animation in past years, it's
+            // basically using this layout. It's pretty domain-specific, and probably
+            // not worth getting into too much. You won't be calling this method, but
+            // if you're finding yourself making a complex strut layout, you might end
+            // up writing someting similar.
+            StrutLayout[] layouts = StrutLayoutFactory.ConcentricFromStartingPoints(
+              this.config,
+              // This list of points was determined manually
+              new HashSet<int>(new int[] { 22, 26, 30, 34, 38, 70 }),
+              4
+            );
+
+            //-----------------------------------------------------------------------
+            // SETTING LEDS
+            //-----------------------------------------------------------------------
+
+            // This method is used to set an LED to a color. You identify the LED
+            // using a pair of a strut index and an LED index (see STRUT LAYOUTS
+            // above), and then provide a color to set that LED to.
+            this.dome.SetPixel(15, 20, firstSingleColor);
+            for (int i = 0; i < LEDDomeOutput.GetNumStruts(); i++) {
+                Strut strut = Strut.FromIndex(this.config, i);
+                var leds = LEDDomeOutput.GetNumLEDs(i);
+                for (int j = 0; j < leds; j++) {
+                    var pixel_p = StrutLayoutFactory.GetProjectedLEDPointParametric(i, j);
+                }
+            }
+
+            // No messages will be sent to the Beaglebone until Flush is called. This
+            // makes it imperative that you call Flush at the end of Visualize, or
+            // whenever you want to update the LEDs. The LEDs themselves are stateful,
+            // and will maintain whatever color you set them to until they lose power.
+            this.dome.Flush();
+        }
+
+    }
+
+}

--- a/Spectrum/Visualizers/LEDDomeRaceVisualizer.cs
+++ b/Spectrum/Visualizers/LEDDomeRaceVisualizer.cs
@@ -33,8 +33,9 @@ namespace Spectrum {
     }
 
     /**
-     * The Configuration Settings. Each item is an can add as many bands as you would like.
-     * The first will always be closest to the ground, and the last will be at the north pole.
+     * The Configuration Settings. Each item is a "racing" band, you can add as many bands 
+     * as you would like. The first will always be closest to the ground, and the last will 
+     * be at the north pole. The settings for each band:
      * Rotation: How does the racer rotate around the center.
      * Size: How large will it be, small, medium, large, or full (complete circle)
      * Coloring: How it will be colored, multiple colors, fading out, expoenential fade out, or constant.
@@ -47,7 +48,7 @@ namespace Spectrum {
     };
 
     // How much spacing should be in between each racer. 
-    // Determines racer size. 
+    // Determines racer "padding". 
     // 0 means right next to eachother. 1 means they have a size of 0.
     private double racer_spacing = 0;
 

--- a/Spectrum/Visualizers/LEDDomeRaceVisualizer.cs
+++ b/Spectrum/Visualizers/LEDDomeRaceVisualizer.cs
@@ -43,7 +43,7 @@ namespace Spectrum
     public RacerConfig[] racerConfig = { 
       new RacerConfig(Rotation.VolumeSquared, Size.Full, Coloring.Multi),
       new RacerConfig(Rotation.VolumeSquared, Size.Medium, Coloring.FadeExp),
-      new RacerConfig(Rotation.Beat, Size.Medium, Coloring.Fade),
+      new RacerConfig(Rotation.Beat, Size.Small, Coloring.FadeExp),
       new RacerConfig(Rotation.Constant, Size.Full, Coloring.Multi),
     };
 
@@ -122,8 +122,10 @@ namespace Spectrum
         if(config.beatBroadcaster.MeasureLength == -1) {
           return 0;
         }
-        int maxBPM = 500;
-        return 1.0 * config.beatBroadcaster.MeasureLength / maxBPM / 3;
+        // Taken from the BPM toString method, and multiply by 60 for seconds.
+        double BPS = 1000.0 / config.beatBroadcaster.MeasureLength;
+        // Make a full revolution after 4 beats.
+        return 1.0 * BPS / 4;
       }
       public double RevsPerSecondConstant(AudioInput audio, Configuration config) {
         return 1.0 * config.domeVolumeRotationSpeed / 4;

--- a/Spectrum/Windows/MainWindow.xaml
+++ b/Spectrum/Windows/MainWindow.xaml
@@ -367,6 +367,7 @@
                                     <ComboBox x:Name="domeActiveVisualizer" HorizontalAlignment="Left" VerticalAlignment="Top" Width="140" Margin="80,0,0,0">
                                         <ComboBoxItem x:Name="domeActiveVisualizerVolume" Content='"Volume" (OG)' IsSelected="True" />
                                         <ComboBoxItem x:Name="domeActiveVisualizerRadial" Content='Radial Effects' />
+                                        <ComboBoxItem x:Name="domeActiveVisualizerRace" Content='Race' />
                                         <ComboBoxItem x:Name="domeActiveVisualizerJkTest" Content='JK TEST' />
                                     </ComboBox>
                                 </Grid>

--- a/Spectrum/Windows/MainWindow.xaml.cs
+++ b/Spectrum/Windows/MainWindow.xaml.cs
@@ -192,6 +192,7 @@ namespace Spectrum {
       this.Bind("domeActiveVis", this.domeActiveVisualizer, ComboBox.SelectedItemProperty, BindingMode.TwoWay, new SpecificValuesConverter<int, ComboBoxItem>(new Dictionary<int, ComboBoxItem> {
         [0] = this.domeActiveVisualizerVolume,
         [1] = this.domeActiveVisualizerRadial,
+        [2] = this.domeActiveVisualizerRace,
         [999] = this.domeActiveVisualizerJkTest }, true));
       this.Bind("boardBeagleboneOPCAddress", this.boardBeagleboneOPCHostAndPort, TextBox.TextProperty);
       this.Bind("boardBeagleboneOPCFPS", this.boardBeagleboneOPCFPSLabel, Label.ContentProperty);

--- a/Spectrum/Windows/VJHUDWindow.xaml
+++ b/Spectrum/Windows/VJHUDWindow.xaml
@@ -369,7 +369,6 @@
                 <ComboBoxItem x:Name="domeActiveVisualizerVolume" Content='"Volume" (OG)' IsSelected="True" />
                 <ComboBoxItem x:Name="domeActiveVisualizerRadial" Content='Radial Effects' />
                 <ComboBoxItem x:Name="domeActiveVisualizerRace" Content='Race' />
-                <ComboBoxItem x:Name="domeActiveVisualizerJkTest" Content='JK TEST' />
               </ComboBox>
             </Grid>
             <Grid Height="24">

--- a/Spectrum/Windows/VJHUDWindow.xaml
+++ b/Spectrum/Windows/VJHUDWindow.xaml
@@ -368,6 +368,7 @@
               <ComboBox x:Name="domeActiveVisualizer" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="100,0,0,0" Width="140">
                 <ComboBoxItem x:Name="domeActiveVisualizerVolume" Content='"Volume" (OG)' IsSelected="True" />
                 <ComboBoxItem x:Name="domeActiveVisualizerRadial" Content='Radial Effects' />
+                <ComboBoxItem x:Name="domeActiveVisualizerRace" Content='Race' />
                 <ComboBoxItem x:Name="domeActiveVisualizerJkTest" Content='JK TEST' />
               </ComboBox>
             </Grid>


### PR DESCRIPTION
Here's a new visualizer. The idea behind it is that the dome is broken up vertically into several "racing" bands. Each band is controlled by volume, beat, is still, or rotates at a constant rate. Currently, the bands are hard-coded in there in the `RacerConfig` array, but if this seems to be popular, I'd be happy to adding some config options from within the VJ setup.

It's probably not as cool as I imagined in my head, but will be a nice variation to throw in. I'm curious as to whether it will make people motion sick with all the spinning swirly things around them.

Here's a screenshot of it in action in its default setup:

![image](https://user-images.githubusercontent.com/671052/63196241-d24ac200-c042-11e9-92e7-ee8662c29ec4.png)
