### PR TITLE
new bubble visualizer, use colors according to level, some other changes

### DIFF
--- a/Base/LEDColor.cs
+++ b/Base/LEDColor.cs
@@ -169,7 +169,7 @@ namespace Spectrum.Base {
         distance = Math.Min(
           Math.Abs(pixelPos - focusPos),
           1 - Math.Abs(pixelPos - focusPos)
-        );
+        ) * 2.0;
       } else {
         distance = Math.Abs(pixelPos - focusPos);
       }

--- a/Spectrum/Windows/VJHUDWindow.xaml
+++ b/Spectrum/Windows/VJHUDWindow.xaml
@@ -401,6 +401,7 @@
                 <ComboBoxItem x:Name="dre0" Content="Radar" IsSelected="True" />
                 <ComboBoxItem x:Name="dre1" Content="Pulse" />
                 <ComboBoxItem x:Name="dre2" Content="Spiral" />
+                <ComboBoxItem x:Name="dre3" Content="Bubbles" />
               </ComboBox>
             </Grid>
             <Grid Height="24">

--- a/Spectrum/Windows/VJHUDWindow.xaml
+++ b/Spectrum/Windows/VJHUDWindow.xaml
@@ -368,7 +368,6 @@
               <ComboBox x:Name="domeActiveVisualizer" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="100,0,0,0" Width="140">
                 <ComboBoxItem x:Name="domeActiveVisualizerVolume" Content='"Volume" (OG)' IsSelected="True" />
                 <ComboBoxItem x:Name="domeActiveVisualizerRadial" Content='Radial Effects' />
-                <ComboBoxItem x:Name="domeActiveVisualizerJkTest" Content='JK TEST' />
               </ComboBox>
             </Grid>
             <Grid Height="24">

--- a/Spectrum/Windows/VJHUDWindow.xaml.cs
+++ b/Spectrum/Windows/VJHUDWindow.xaml.cs
@@ -225,8 +225,7 @@ namespace Spectrum {
 
       this.Bind("domeActiveVis", this.domeActiveVisualizer, ComboBox.SelectedItemProperty, BindingMode.TwoWay, new SpecificValuesConverter<int, ComboBoxItem>(new Dictionary<int, ComboBoxItem> {
         [0] = this.domeActiveVisualizerVolume,
-        [1] = this.domeActiveVisualizerRadial,
-        [999] = this.domeActiveVisualizerJkTest
+        [1] = this.domeActiveVisualizerRadial
       }, true));
       this.Bind("domeVolumeRotationSpeed", this.domeVolumeRotationSpeed, ComboBox.SelectedItemProperty, BindingMode.TwoWay, new SpecificValuesConverter<double, ComboBoxItem>(new Dictionary<double, ComboBoxItem> { [0] = this.dprs0, [0.125] = this.dprs1, [0.25] = this.dprs2, [0.5] = this.dprs3, [1.0] = this.dprs4, [2.0] = this.dprs5, [4.0] = this.dprs6 }, true));
       this.Bind("domeGradientSpeed", this.domeGradientSpeed, ComboBox.SelectedItemProperty, BindingMode.TwoWay, new SpecificValuesConverter<double, ComboBoxItem>(new Dictionary<double, ComboBoxItem> { [0] = this.dsrs0, [0.125] = this.dsrs1, [0.25] = this.dsrs2, [0.5] = this.dsrs3, [1.0] = this.dsrs4, [2.0] = this.dsrs5, [4.0] = this.dsrs6 }, true));


### PR DESCRIPTION
I experimented with some ideas, but most of them didn't look good.  Here's what I ended up with:

- new "bubble" visualizer (a failed attempt at making a star, but i kept it)
- use level to determine which gradient to use
- slowed down rotation of radial effects
- adjust level using Sqrt to be more sensitive at lower levels
- fixed bug in GetGradientColor (was previously mapping to 0-0.5 when "wrap" option was used)

Things that didn't work very well:
- using multiple gradients at once, using dist*level to determine which one to use - looked insane
- using dist < level or dist > level to limit shapes - almost looked good but didn't quite work
- moving "pulse" in and out based on level - again, almost looked good but not quite
- ???