### PR TITLE
Update poi visualization

### DIFF
--- a/Spectrum/DatagramHandler.cs
+++ b/Spectrum/DatagramHandler.cs
@@ -24,14 +24,22 @@ namespace Spectrum {
         int actionFlag = buffer[13]; // what the buttons do
         return (device: new OrientationDevice(timestamp, deviceType, new Quaternion(0, 0, 0, 1), sensorState), actionFlag: actionFlag);
       }
+      // Device type 2 - Adam's poi
       if (deviceType == 2) {
         short W = BitConverter.ToInt16(buffer, 6);
         short X = BitConverter.ToInt16(buffer, 8);
         short Y = BitConverter.ToInt16(buffer, 10);
         short Z = BitConverter.ToInt16(buffer, 12);
-        double rotationalSpeed = BitConverter.ToUInt16(buffer, 14) / 65536.0f;
+        // Note the poi only have 1 accessable button while in use.
+        // This could be used for calibration.
+        // I am leaving this here in case I fix the external button on my poi.
+        //int actionFlag = buffer[13];
+
+        // avgDistance is the average angular distance traveled in a time period
+        double avgDistanceShort = BitConverter.ToUInt16(buffer, 15) / 65536.0;
+
         Quaternion sensorState = new Quaternion(X / 16384.0f, Y / 16384.0f, Z / 16384.0f, W / 16384.0f);
-        return (device: new OrientationDevice(timestamp, deviceType, new Quaternion(0, 0, 0, 1), sensorState, rotationalSpeed), actionFlag: 0);
+        return (device: new OrientationDevice(timestamp, deviceType, new Quaternion(0, 0, 0, 1), sensorState, avgDistanceShort), actionFlag: 0);
       }
       return (device: new OrientationDevice(-1, -1, new Quaternion(0, 0, 0, 0), new Quaternion(0, 0, 0, 0)), actionFlag: 0);
     }

--- a/Spectrum/OrientationDevice.cs
+++ b/Spectrum/OrientationDevice.cs
@@ -6,7 +6,7 @@ namespace Spectrum {
     public int deviceType { get; }
     public Quaternion calibrationOrigin { get; set; }
     public Quaternion currentOrientation { get; set; }
-    public double rotationalSpeed { get; set; }
+    public double avgDistanceShort { get; set; }
     public bool hasSpeed { get; set; }
     public int actionFlag { get; set; }
 
@@ -21,18 +21,25 @@ namespace Spectrum {
     }
 
     // Device type 2 - Adam's poi
-    public OrientationDevice(int timestamp, int deviceType, Quaternion calibrationOrigin, Quaternion currentOrientation, double rotationalSpeed) {
+    public OrientationDevice(int timestamp, int deviceType, Quaternion calibrationOrigin, Quaternion currentOrientation, double avgDistanceShort) {
       this.timestamp = timestamp;
       this.deviceType = deviceType;
       this.calibrationOrigin = calibrationOrigin;
       this.currentOrientation = currentOrientation;
       this.hasSpeed = true;
-      this.rotationalSpeed = rotationalSpeed;
+      this.avgDistanceShort = avgDistanceShort;
       actionFlag = 0;
     }
 
     public void calibrate() {
       calibrationOrigin = currentOrientation;
+    }
+
+    public double currentAverageDistance() {
+      if (!hasSpeed) {
+        return 0f;
+      }
+      return avgDistanceShort;
     }
 
     public Quaternion currentRotation() {

--- a/Spectrum/OrientationInput.cs
+++ b/Spectrum/OrientationInput.cs
@@ -98,6 +98,8 @@ namespace Spectrum {
           //   assuming it was off for more than a second
           devices[deviceId].timestamp = timestamp;
           devices[deviceId].currentOrientation = datagramOut.device.currentOrientation;
+          // This took me a while to track down. We must set the avgDistanceShort from the datagram
+          devices[deviceId].avgDistanceShort = datagramOut.device.avgDistanceShort;
         }
       }
       u.BeginReceive(new AsyncCallback(ReceiveCallback), s);
@@ -167,7 +169,12 @@ namespace Spectrum {
       }
     }
 
+    // onlyPoi is used to change visualization to accentuate poi
     public bool onlyPoi() {
+      // All devices are not poi if there are no devices.
+      if (devices.Count == 0) {
+        return false;
+      }
       return n_poi == devices.Count;
     }
   }


### PR DESCRIPTION
Updates to inverse circle size and state that it is average distance, which is kind of like rotational speed, though back and forth movements add up for average distance.

Matched with this poi firmware commit: https://github.com/adamryman/mindshark-dome-poi-control-esp32c3-bno055/tree/a1949811c1dd24618683f5c85e2d5ada79d28aea